### PR TITLE
Fix tests for architectures without AES hardware support

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1800,7 +1800,7 @@ func TestOutgoingTLS(t *testing.T) {
 Hello, world!
 `, ts.URL)
 
-	if got := buf.String(); got != want {
+	if got := strings.Replace(buf.String(), "TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_128_GCM_SHA256", -1); got != want {
 		t.Errorf("logged HTTP request %s; want %s", got, want)
 	}
 
@@ -1867,7 +1867,7 @@ func TestOutgoingTLSInsecureSkipVerify(t *testing.T) {
 Hello, world!
 `, ts.URL)
 
-	got := buf.String()
+	got := strings.Replace(buf.String(), "TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_128_GCM_SHA256", -1)
 
 	if got != want {
 		t.Errorf("logged HTTP request %s; want %s", got, want)
@@ -2147,7 +2147,7 @@ func TestOutgoingHTTP2MutualTLS(t *testing.T) {
 Hello, world!
 `, host, port)
 
-	if got := buf.String(); got != want {
+	if got := strings.Replace(buf.String(), "TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_128_GCM_SHA256", -1); got != want {
 		t.Errorf("logged HTTP request %s; want %s", got, want)
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1703,7 +1703,7 @@ func TestIncomingTLS(t *testing.T) {
 Hello, world!
 `, is.req.RemoteAddr)
 
-	if got := buf.String(); got != want {
+	if got := strings.Replace(buf.String(), "TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_128_GCM_SHA256", -1); got != want {
 		t.Errorf("logged HTTP request %s; want %s", got, want)
 	}
 }
@@ -1847,7 +1847,7 @@ func TestIncomingMutualTLS(t *testing.T) {
 Hello, world!
 `, host, is.req.RemoteAddr, port)
 
-	if got := buf.String(); got != want {
+	if got := strings.Replace(buf.String(), "TLS_CHACHA20_POLY1305_SHA256", "TLS_AES_128_GCM_SHA256", -1); got != want {
 		t.Errorf("logged HTTP request %s; want %s", got, want)
 	}
 }


### PR DESCRIPTION
https://github.com/golang/go/blob/4aa1efed4853ea067d665a952eee77c52faac774/src/crypto/tls/cipher_suites.go#L342-L355

Starting with Go 1.16, ChaCha (`TLS_CHACHA20_POLY1305_SHA256`)
is picked over AES (`TLS_AES_128_GCM_SHA256`) for TLS 1.3 on machines
that do not have AES hardware support, e.g. on [armhf](https://ci.debian.net/packages/g/golang-github-henvic-httpretty/unstable/armhf/), [386](https://ci.debian.net/packages/g/golang-github-henvic-httpretty/unstable/i386/) and [ppc64le](https://ci.debian.net/packages/g/golang-github-henvic-httpretty/unstable/ppc64el/),
as caught by Debian [autopkgtest for golang-github-henvic-httpretty/0.0.6-2](https://ci.debian.net/packages/g/golang-github-henvic-httpretty/)
between November 2021 and March 2022.

The test failure can be reproduced locally with `GOARCH=386 go test ./...`

Reference code for different preferred TLS 1.3 ciphers in Go 1.18:
https://github.com/golang/go/blob/go1.18/src/crypto/tls/cipher_suites.go#L342-L367
https://github.com/golang/go/blob/go1.18/src/crypto/tls/handshake_client.go#L124-L129

This commit accommodates `TLS_CHACHA20_POLY1305_SHA256` in addition to
`TLS_AES_128_GCM_SHA256` in the TLS 1.3 tests.