### PR TITLE
Avoid mangling response bodies of unknown length

### DIFF
--- a/httpretty_test.go
+++ b/httpretty_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -21,8 +20,9 @@ import (
 // See https://golang.org/issue/30597
 var race bool
 
-//go:embed testdata/petition.golden
 // sample from http://bastiat.org/fr/petition.html
+//
+//go:embed testdata/petition.golden
 var petition string
 
 func TestPrintRequest(t *testing.T) {
@@ -223,8 +223,12 @@ func testBody(t *testing.T, r io.Reader, want []byte) {
 	if err != nil {
 		t.Errorf("expected no error reading response body, got %v instead", err)
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf(`got body = %v, wanted %v`, string(got), string(want))
+	if !bytes.Equal(got, want) {
+		if len(got) != len(want) && (len(got) > 100 || len(want) > 100) {
+			t.Errorf(`got body length = %v, wanted %v`, len(got), len(want))
+		} else {
+			t.Errorf(`got body = %v, wanted %v`, string(got), string(want))
+		}
 	}
 }
 

--- a/printer.go
+++ b/printer.go
@@ -1,7 +1,6 @@
 package httpretty
 
 import (
-	"bufio"
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
@@ -265,12 +264,11 @@ func isBinaryMediatype(mediatype string) bool {
 const maxDefaultUnknownReadable = 4096 // bytes
 
 func (p *printer) printBodyUnknownLength(contentType string, maxLength int64, r io.ReadCloser) (newBody io.ReadCloser) {
-	shortReader := bufio.NewReader(r)
 	if maxLength == 0 {
 		maxLength = maxDefaultUnknownReadable
 	}
 	pb := make([]byte, maxLength+1) // read one extra bit to assure the length is longer than acceptable
-	n, err := io.ReadFull(shortReader, pb)
+	n, err := io.ReadFull(r, pb)
 	pb = pb[0:n] // trim any nil symbols left after writing in the byte slice.
 	buf := bytes.NewReader(pb)
 	newBody = newBodyReaderBuf(buf, r)


### PR DESCRIPTION
When a body of unknown length cannot be printed due to being larger than MaxResponseBody, ensure that the resulting body reader will produce the original body intact.

Fixes https://github.com/henvic/httpretty/issues/15