### PR TITLE
test: fix matching tls certificate error for Go1.20

### DIFF
--- a/testdata/log.txtar
+++ b/testdata/log.txtar
@@ -670,7 +670,7 @@ Hello, world!
 > Host: example\.com
 > User-Agent: Robot/0\.1 crawler@example\.com
 
-\* x509: .+
+\* .*x509: .+
 -- TestOutgoingTooLongResponse --
 * Request to %s
 > GET /long-response HTTP/1.1


### PR DESCRIPTION
Go1.20 adds more info to the tls error. Now it reports:

tls: failed to verify certificate: x509: certificate signed by unknown authority

Close #16