### PR TITLE
Add Align to align HTTP headers

### DIFF
--- a/httpretty.go
+++ b/httpretty.go
@@ -117,6 +117,9 @@ type Logger struct {
 	// Colors set ANSI escape codes that terminals use to print text in different colors.
 	Colors bool
 
+	// Align HTTP headers.
+	Align bool
+
 	// Formatters for the request and response bodies.
 	// No standard formatters are used. You need to add what you want to use explicitly.
 	// We provide a JSONFormatter for convenience (add it manually).

--- a/httpretty_test.go
+++ b/httpretty_test.go
@@ -51,6 +51,38 @@ func TestPrintRequest(t *testing.T) {
 	}
 }
 
+func TestPrintRequestWithAlign(t *testing.T) {
+	t.Parallel()
+	var req, err = http.NewRequest(http.MethodPost, "http://wxww.example.com/", nil)
+	if err != nil {
+		panic(err)
+	}
+	req.Header.Set("Header", "foo")
+	req.Header.Set("Other-Header", "bar")
+
+	logger := &Logger{
+		TLS:            true,
+		RequestHeader:  true,
+		RequestBody:    true,
+		ResponseHeader: true,
+		ResponseBody:   true,
+		Align:          true,
+	}
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	logger.PrintRequest(req)
+
+	want := `> POST / HTTP/1.1
+> Host:         wxww.example.com
+> Header:       foo
+> Other-Header: bar
+
+`
+	if got := buf.String(); got != want {
+		t.Errorf("PrintRequest(req) = %v, wanted %v", got, want)
+	}
+}
+
 func TestPrintRequestWithColors(t *testing.T) {
 	t.Parallel()
 	var req, err = http.NewRequest(http.MethodPost, "http://wxww.example.com/", nil)


### PR DESCRIPTION
IMHO this makes stuff rather more readable/scannable. Some people may not like it, so I added it as an option.

Will automatically align to the longest header; I modified the sortHeaderKeys() so we don't need to do an extra loop for it.

Also pass the Host header to printHeaders() so it's aligned too. Do some special-fu to make sure it still prints as the first.

Before;

	* Request at 2024-09-19 15:19:15.459694244 +0100 IST m=+1.001660288
	* Request to http://localhost:8081/api/3/ping
	> GET /api/3/ping HTTP/1.1
	> Host: localhost:8081
	> Accept: application/json; charset=utf-8
	> Authorization: ApiKey ████████████████████
	> Content-Type: application/json; charset=utf-8
	> User-Agent: alfred/

	< HTTP/1.1 200 OK
	< Cache-Control: no-store,no-cache
	< Content-Length: 88
	< Content-Security-Policy: default-src 'self'; img-src 'self' blob: data:;
	< Content-Type: application/json; charset=utf-8
	< Date: Thu, 19 Sep 2024 14:19:15 GMT
	< Referrer-Policy: same-origin
	< X-Content-Type-Options: nosniff
	< X-Frame-Options: SAMEORIGIN
	< X-Powered-By: Alfred
	< X-Xss-Protection: 1; mode=block

	{
		"ftm_version": "3.7.0",
		"role": 4,
		"title": "Alfred",
		"version": "d67f396b"
	}

	* Request took 9.251101ms

After:

	* Request at 2024-09-19 15:18:45.255328802 +0100 IST m=+1.001249794
	* Request to http://localhost:8081/api/3/ping
	> GET /api/3/ping HTTP/1.1
	> Host:          localhost:8081
	> Accept:        application/json; charset=utf-8
	> Authorization: ApiKey ████████████████████
	> Content-Type:  application/json; charset=utf-8
	> User-Agent:    alfred/

	< HTTP/1.1 200 OK
	< Cache-Control:           no-store,no-cache
	< Content-Length:          88
	< Content-Security-Policy: default-src 'self'; img-src 'self' blob: data:;
	< Content-Type:            application/json; charset=utf-8
	< Date:                    Thu, 19 Sep 2024 14:18:45 GMT
	< Referrer-Policy:         same-origin
	< X-Content-Type-Options:  nosniff
	< X-Frame-Options:         SAMEORIGIN
	< X-Powered-By:            Alfred
	< X-Xss-Protection:        1; mode=block

	{
		"ftm_version": "3.7.0",
		"role": 4,
		"title": "Alfred",
		"version": "d67f396b"
	}

	* Request took 9.251101ms